### PR TITLE
Upgrade (most of) xt_qtaguid to AOSP 4.3 version (fix data transfer arro...

### DIFF
--- a/net/netfilter/xt_qtaguid.c
+++ b/net/netfilter/xt_qtaguid.c
@@ -13,7 +13,6 @@
  * via the DEFAULT_DEBUG_MASK. See xt_qtaguid_internal.h.
  */
 #define DEBUG
-#define TAG "qtaguid"
 
 #include "atomic.h"
 
@@ -39,7 +38,7 @@
 /* Compat */
 #ifndef pr_warn_once
 #define pr_warn_once(fmt, ...) \
-        printk_once(KERN_WARNING pr_fmt(fmt), ##__VA_ARGS__)
+	printk_once(KERN_WARNING pr_fmt(fmt), ##__VA_ARGS__)
 #endif
 #define xt_socket_put_sk(sk) qtaguid_put_sk(sk)
 
@@ -59,25 +58,22 @@ static unsigned int proc_stats_perms = S_IRUGO;
 module_param_named(stats_perms, proc_stats_perms, uint, S_IRUGO | S_IWUSR);
 
 static struct proc_dir_entry *xt_qtaguid_ctrl_file;
-#ifdef CONFIG_ANDROID_PARANOID_NETWORK
+
+/* Everybody can write. But proc_ctrl_write_limited is true by default which
+ * limits what can be controlled. See the can_*() functions.
+ */
 static unsigned int proc_ctrl_perms = S_IRUGO | S_IWUGO;
-#else
-static unsigned int proc_ctrl_perms = S_IRUGO | S_IWUSR;
-#endif
 module_param_named(ctrl_perms, proc_ctrl_perms, uint, S_IRUGO | S_IWUSR);
 
-#ifdef CONFIG_ANDROID_PARANOID_NETWORK
-#include <linux/android_aid.h>
-static gid_t proc_stats_readall_gid = AID_NET_BW_STATS;
-static gid_t proc_ctrl_write_gid = AID_NET_BW_ACCT;
-#else
-/* 0 means, don't limit anybody */
-static gid_t proc_stats_readall_gid;
-static gid_t proc_ctrl_write_gid;
-#endif
-module_param_named(stats_readall_gid, proc_stats_readall_gid, uint,
+/* Limited by default, so the gid of the ctrl and stats proc entries
+ * will limit what can be done. See the can_*() functions.
+ */
+static bool proc_stats_readall_limited = true;
+static bool proc_ctrl_write_limited = true;
+
+module_param_named(stats_readall_limited, proc_stats_readall_limited, bool,
 		   S_IRUGO | S_IWUSR);
-module_param_named(ctrl_write_gid, proc_ctrl_write_gid, uint,
+module_param_named(ctrl_write_limited, proc_ctrl_write_limited, bool,
 		   S_IRUGO | S_IWUSR);
 
 /*
@@ -114,14 +110,21 @@ module_param_named(tag_tracking_passive, qtu_proc_handling_passive, bool,
 
 #define QTU_DEV_NAME "xt_qtaguid"
 
-//uint qtaguid_debug_mask = DEFAULT_DEBUG_MASK;
+uint qtaguid_debug_mask = DEFAULT_DEBUG_MASK;
 module_param_named(debug_mask, qtaguid_debug_mask, uint, S_IRUGO | S_IWUSR);
 
 /*---------------------------------------------------------------------------*/
 static const char *iface_stat_procdirname = "iface_stat";
 static struct proc_dir_entry *iface_stat_procdir;
+/*
+ * The iface_stat_all* will go away once userspace gets use to the new fields
+ * that have a format line.
+ */
 static const char *iface_stat_all_procfilename = "iface_stat_all";
 static struct proc_dir_entry *iface_stat_all_procfile;
+static const char *iface_stat_fmt_procfilename = "iface_stat_fmt";
+static struct proc_dir_entry *iface_stat_fmt_procfile;
+
 
 /*
  * Ordering of locks:
@@ -134,9 +137,9 @@ static struct proc_dir_entry *iface_stat_all_procfile;
  * Notice how sock_tag_list_lock is held sometimes when uid_tag_data_tree_lock
  * is acquired.
  *
- * Call tree with all lock holders as of 2011-09-25:
+ * Call tree with all lock holders as of 2012-04-27:
  *
- * iface_stat_all_proc_read()
+ * iface_stat_fmt_proc_read()
  *   iface_stat_list_lock
  *     (struct iface_stat)
  *
@@ -241,8 +244,9 @@ static struct qtaguid_event_counts qtu_events;
 static bool can_manipulate_uids(void)
 {
 	/* root pwnd */
-	return unlikely(!current_fsuid()) || unlikely(!proc_ctrl_write_gid)
-		|| in_egroup_p(proc_ctrl_write_gid);
+	return in_egroup_p(xt_qtaguid_ctrl_file->gid)
+		|| unlikely(!current_fsuid()) || unlikely(!proc_ctrl_write_limited)
+		|| unlikely(current_fsuid() == xt_qtaguid_ctrl_file->uid);
 }
 
 static bool can_impersonate_uid(uid_t uid)
@@ -253,9 +257,10 @@ static bool can_impersonate_uid(uid_t uid)
 static bool can_read_other_uid_stats(uid_t uid)
 {
 	/* root pwnd */
-	return unlikely(!current_fsuid()) || uid == current_fsuid()
-		|| unlikely(!proc_stats_readall_gid)
-		|| in_egroup_p(proc_stats_readall_gid);
+	return in_egroup_p(xt_qtaguid_stats_file->gid)
+		|| unlikely(!current_fsuid()) || uid == current_fsuid()
+		|| unlikely(!proc_stats_readall_limited)
+		|| unlikely(current_fsuid() == xt_qtaguid_ctrl_file->uid);
 }
 
 static inline void dc_add_byte_packets(struct data_counters *counters, int set,
@@ -268,24 +273,6 @@ static inline void dc_add_byte_packets(struct data_counters *counters, int set,
 	counters->bpc[set][direction][ifs_proto].packets += packets;
 }
 
-static inline uint64_t dc_sum_bytes(struct data_counters *counters,
-				    int set,
-				    enum ifs_tx_rx direction)
-{
-	return counters->bpc[set][direction][IFS_TCP].bytes
-		+ counters->bpc[set][direction][IFS_UDP].bytes
-		+ counters->bpc[set][direction][IFS_PROTO_OTHER].bytes;
-}
-
-static inline uint64_t dc_sum_packets(struct data_counters *counters,
-				      int set,
-				      enum ifs_tx_rx direction)
-{
-	return counters->bpc[set][direction][IFS_TCP].packets
-		+ counters->bpc[set][direction][IFS_UDP].packets
-		+ counters->bpc[set][direction][IFS_PROTO_OTHER].packets;
-}
-
 static struct tag_node *tag_node_tree_search(struct rb_root *root, tag_t tag)
 {
 	struct rb_node *node = root->rb_node;
@@ -293,10 +280,10 @@ static struct tag_node *tag_node_tree_search(struct rb_root *root, tag_t tag)
 	while (node) {
 		struct tag_node *data = rb_entry(node, struct tag_node, node);
 		int result;
-		RB_DEBUG(TAG": tag_node_tree_search(0x%llx): "
+		RB_DEBUG("qtaguid: tag_node_tree_search(0x%llx): "
 			 " node=%p data=%p\n", tag, node, data);
 		result = tag_compare(tag, data->tag);
-		RB_DEBUG(TAG": tag_node_tree_search(0x%llx): "
+		RB_DEBUG("qtaguid: tag_node_tree_search(0x%llx): "
 			 " data.tag=0x%llx (uid=%u) res=%d\n",
 			 tag, data->tag, get_uid_from_tag(data->tag), result);
 		if (result < 0)
@@ -318,7 +305,7 @@ static void tag_node_tree_insert(struct tag_node *data, struct rb_root *root)
 		struct tag_node *this = rb_entry(*new, struct tag_node,
 						 node);
 		int result = tag_compare(data->tag, this->tag);
-		RB_DEBUG(TAG": %s(): tag=0x%llx"
+		RB_DEBUG("qtaguid: %s(): tag=0x%llx"
 			 " (uid=%u)\n", __func__,
 			 this->tag,
 			 get_uid_from_tag(this->tag));
@@ -427,7 +414,7 @@ static void sock_tag_tree_erase(struct rb_root *st_to_free_tree)
 	while (node) {
 		st_entry = rb_entry(node, struct sock_tag, sock_node);
 		node = rb_next(node);
-		CT_DEBUG(TAG": %s(): "
+		CT_DEBUG("qtaguid: %s(): "
 			 "erase st: sk=%p tag=0x%llx (uid=%u)\n", __func__,
 			 st_entry->sk,
 			 st_entry->tag,
@@ -538,7 +525,7 @@ struct uid_tag_data *get_uid_data(uid_t uid, bool *found_res)
 
 	/* Look for top level uid_tag_data for the UID */
 	utd_entry = uid_tag_data_tree_search(&uid_tag_data_tree, uid);
-	DR_DEBUG(TAG": get_uid_data(%u) utd=%p\n", uid, utd_entry);
+	DR_DEBUG("qtaguid: get_uid_data(%u) utd=%p\n", uid, utd_entry);
 
 	if (found_res)
 		*found_res = utd_entry;
@@ -547,7 +534,7 @@ struct uid_tag_data *get_uid_data(uid_t uid, bool *found_res)
 
 	utd_entry = kzalloc(sizeof(*utd_entry), GFP_ATOMIC);
 	if (!utd_entry) {
-		pr_err(TAG": get_uid_data(%u): "
+		pr_err("qtaguid: get_uid_data(%u): "
 		       "tag data alloc failed\n", uid);
 		return ERR_PTR(-ENOMEM);
 	}
@@ -555,7 +542,7 @@ struct uid_tag_data *get_uid_data(uid_t uid, bool *found_res)
 	utd_entry->uid = uid;
 	utd_entry->tag_ref_tree = RB_ROOT;
 	uid_tag_data_tree_insert(utd_entry, &uid_tag_data_tree);
-	DR_DEBUG(TAG": get_uid_data(%u) new utd=%p\n", uid, utd_entry);
+	DR_DEBUG("qtaguid: get_uid_data(%u) new utd=%p\n", uid, utd_entry);
 	return utd_entry;
 }
 
@@ -567,7 +554,7 @@ static struct tag_ref *new_tag_ref(tag_t new_tag,
 	int res;
 
 	if (utd_entry->num_active_tags + 1 > max_sock_tags) {
-		pr_info(TAG": new_tag_ref(0x%llx): "
+		pr_info("qtaguid: new_tag_ref(0x%llx): "
 			"tag ref alloc quota exceeded. max=%d\n",
 			new_tag, max_sock_tags);
 		res = -EMFILE;
@@ -577,7 +564,7 @@ static struct tag_ref *new_tag_ref(tag_t new_tag,
 
 	tr_entry = kzalloc(sizeof(*tr_entry), GFP_ATOMIC);
 	if (!tr_entry) {
-		pr_err(TAG": new_tag_ref(0x%llx): "
+		pr_err("qtaguid: new_tag_ref(0x%llx): "
 		       "tag ref alloc failed\n",
 		       new_tag);
 		res = -ENOMEM;
@@ -587,7 +574,7 @@ static struct tag_ref *new_tag_ref(tag_t new_tag,
 	/* tr_entry->num_sock_tags  handled by caller */
 	utd_entry->num_active_tags++;
 	tag_ref_tree_insert(tr_entry, &utd_entry->tag_ref_tree);
-	DR_DEBUG(TAG": new_tag_ref(0x%llx): "
+	DR_DEBUG("qtaguid: new_tag_ref(0x%llx): "
 		 " inserted new tag ref %p\n",
 		 new_tag, tr_entry);
 	return tr_entry;
@@ -604,7 +591,7 @@ static struct tag_ref *lookup_tag_ref(tag_t full_tag,
 	bool found_utd;
 	uid_t uid = get_uid_from_tag(full_tag);
 
-	DR_DEBUG(TAG": lookup_tag_ref(tag=0x%llx (uid=%u))\n",
+	DR_DEBUG("qtaguid: lookup_tag_ref(tag=0x%llx (uid=%u))\n",
 		 full_tag, uid);
 
 	utd_entry = get_uid_data(uid, &found_utd);
@@ -617,7 +604,7 @@ static struct tag_ref *lookup_tag_ref(tag_t full_tag,
 	tr_entry = tag_ref_tree_search(&utd_entry->tag_ref_tree, full_tag);
 	if (utd_res)
 		*utd_res = utd_entry;
-	DR_DEBUG(TAG": lookup_tag_ref(0x%llx) utd_entry=%p tr_entry=%p\n",
+	DR_DEBUG("qtaguid: lookup_tag_ref(0x%llx) utd_entry=%p tr_entry=%p\n",
 		 full_tag, utd_entry, tr_entry);
 	return tr_entry;
 }
@@ -629,7 +616,7 @@ static struct tag_ref *get_tag_ref(tag_t full_tag,
 	struct uid_tag_data *utd_entry;
 	struct tag_ref *tr_entry;
 
-	DR_DEBUG(TAG": get_tag_ref(0x%llx)\n",
+	DR_DEBUG("qtaguid: get_tag_ref(0x%llx)\n",
 		 full_tag);
 	spin_lock_bh(&uid_tag_data_tree_lock);
 	tr_entry = lookup_tag_ref(full_tag, &utd_entry);
@@ -640,7 +627,7 @@ static struct tag_ref *get_tag_ref(tag_t full_tag,
 	spin_unlock_bh(&uid_tag_data_tree_lock);
 	if (utd_res)
 		*utd_res = utd_entry;
-	DR_DEBUG(TAG": get_tag_ref(0x%llx) utd=%p tr=%p\n",
+	DR_DEBUG("qtaguid: get_tag_ref(0x%llx) utd=%p tr=%p\n",
 		 full_tag, utd_entry, tr_entry);
 	return tr_entry;
 }
@@ -651,7 +638,7 @@ static void put_utd_entry(struct uid_tag_data *utd_entry)
 	/* Are we done with the UID tag data entry? */
 	if (RB_EMPTY_ROOT(&utd_entry->tag_ref_tree) &&
 		!utd_entry->num_pqd) {
-		DR_DEBUG(TAG": %s(): "
+		DR_DEBUG("qtaguid: %s(): "
 			 "erase utd_entry=%p uid=%u "
 			 "by pid=%u tgid=%u uid=%u\n", __func__,
 			 utd_entry, utd_entry->uid,
@@ -660,7 +647,7 @@ static void put_utd_entry(struct uid_tag_data *utd_entry)
 		rb_erase(&utd_entry->node, &uid_tag_data_tree);
 		kfree(utd_entry);
 	} else {
-		DR_DEBUG(TAG": %s(): "
+		DR_DEBUG("qtaguid: %s(): "
 			 "utd_entry=%p still has %d tags %d proc_qtu_data\n",
 			 __func__, utd_entry, utd_entry->num_active_tags,
 			 utd_entry->num_pqd);
@@ -677,14 +664,14 @@ static void put_utd_entry(struct uid_tag_data *utd_entry)
 static void free_tag_ref_from_utd_entry(struct tag_ref *tr_entry,
 					struct uid_tag_data *utd_entry)
 {
-	DR_DEBUG(TAG": %s(): %p tag=0x%llx (uid=%u)\n", __func__,
+	DR_DEBUG("qtaguid: %s(): %p tag=0x%llx (uid=%u)\n", __func__,
 		 tr_entry, tr_entry->tn.tag,
 		 get_uid_from_tag(tr_entry->tn.tag));
 	if (!tr_entry->num_sock_tags) {
 		BUG_ON(!utd_entry->num_active_tags);
 		utd_entry->num_active_tags--;
 		rb_erase(&tr_entry->tn.node, &utd_entry->tag_ref_tree);
-		DR_DEBUG(TAG": %s(): erased %p\n", __func__, tr_entry);
+		DR_DEBUG("qtaguid: %s(): erased %p\n", __func__, tr_entry);
 		kfree(tr_entry);
 	}
 }
@@ -695,7 +682,7 @@ static void put_tag_ref_tree(tag_t full_tag, struct uid_tag_data *utd_entry)
 	struct tag_ref *tr_entry;
 	tag_t acct_tag;
 
-	DR_DEBUG(TAG": %s(tag=0x%llx (uid=%u))\n", __func__,
+	DR_DEBUG("qtaguid: %s(tag=0x%llx (uid=%u))\n", __func__,
 		 full_tag, get_uid_from_tag(full_tag));
 	acct_tag = get_atag_from_tag(full_tag);
 	node = rb_first(&utd_entry->tag_ref_tree);
@@ -750,7 +737,7 @@ static int get_active_counter_set(tag_t tag)
 	int active_set = 0;
 	struct tag_counter_set *tcs;
 
-	MT_DEBUG(TAG": get_active_counter_set(tag=0x%llx)"
+	MT_DEBUG("qtaguid: get_active_counter_set(tag=0x%llx)"
 		 " (uid=%u)\n",
 		 tag, get_uid_from_tag(tag));
 	/* For now we only handle UID tags for active sets */
@@ -773,7 +760,7 @@ static struct iface_stat *get_iface_entry(const char *ifname)
 
 	/* Find the entry for tracking the specified tag within the interface */
 	if (ifname == NULL) {
-		pr_info(TAG": iface_stat: get() NULL device name\n");
+		pr_info("qtaguid: iface_stat: get() NULL device name\n");
 		return NULL;
 	}
 
@@ -787,13 +774,61 @@ done:
 	return iface_entry;
 }
 
-static int iface_stat_all_proc_read(char *page, char **num_items_returned,
+/* This is for fmt2 only */
+static int pp_iface_stat_line(bool header, char *outp,
+			      int char_count, struct iface_stat *iface_entry)
+{
+	int len;
+	if (header) {
+		len = snprintf(outp, char_count,
+			       "ifname "
+			       "total_skb_rx_bytes total_skb_rx_packets "
+			       "total_skb_tx_bytes total_skb_tx_packets "
+			       "rx_tcp_bytes rx_tcp_packets "
+			       "rx_udp_bytes rx_udp_packets "
+			       "rx_other_bytes rx_other_packets "
+			       "tx_tcp_bytes tx_tcp_packets "
+			       "tx_udp_bytes tx_udp_packets "
+			       "tx_other_bytes tx_other_packets\n"
+			);
+	} else {
+		struct data_counters *cnts;
+		int cnt_set = 0;   /* We only use one set for the device */
+		cnts = &iface_entry->totals_via_skb;
+		len = snprintf(
+			outp, char_count,
+			"%s "
+			"%llu %llu %llu %llu %llu %llu %llu %llu "
+			"%llu %llu %llu %llu %llu %llu %llu %llu\n",
+			iface_entry->ifname,
+			dc_sum_bytes(cnts, cnt_set, IFS_RX),
+			dc_sum_packets(cnts, cnt_set, IFS_RX),
+			dc_sum_bytes(cnts, cnt_set, IFS_TX),
+			dc_sum_packets(cnts, cnt_set, IFS_TX),
+			cnts->bpc[cnt_set][IFS_RX][IFS_TCP].bytes,
+			cnts->bpc[cnt_set][IFS_RX][IFS_TCP].packets,
+			cnts->bpc[cnt_set][IFS_RX][IFS_UDP].bytes,
+			cnts->bpc[cnt_set][IFS_RX][IFS_UDP].packets,
+			cnts->bpc[cnt_set][IFS_RX][IFS_PROTO_OTHER].bytes,
+			cnts->bpc[cnt_set][IFS_RX][IFS_PROTO_OTHER].packets,
+			cnts->bpc[cnt_set][IFS_TX][IFS_TCP].bytes,
+			cnts->bpc[cnt_set][IFS_TX][IFS_TCP].packets,
+			cnts->bpc[cnt_set][IFS_TX][IFS_UDP].bytes,
+			cnts->bpc[cnt_set][IFS_TX][IFS_UDP].packets,
+			cnts->bpc[cnt_set][IFS_TX][IFS_PROTO_OTHER].bytes,
+			cnts->bpc[cnt_set][IFS_TX][IFS_PROTO_OTHER].packets);
+	}
+	return len;
+}
+
+static int iface_stat_fmt_proc_read(char *page, char **num_items_returned,
 				    off_t items_to_skip, int char_count,
 				    int *eof, void *data)
 {
 	char *outp = page;
 	int item_index = 0;
 	int len;
+	int fmt = (int)data; /* The data is just 1 (old) or 2 (uses fmt) */
 	struct iface_stat *iface_entry;
 	const struct net_device_stats *stats;
 	struct rtnl_link_stats64 no_dev_stats = {0};
@@ -803,13 +838,24 @@ static int iface_stat_all_proc_read(char *page, char **num_items_returned,
 		return 0;
 	}
 
-	CT_DEBUG(TAG":proc iface_stat_all "
+	CT_DEBUG("qtaguid:proc iface_stat_all "
 		 "page=%p *num_items_returned=%p off=%ld "
 		 "char_count=%d *eof=%d\n", page, *num_items_returned,
 		 items_to_skip, char_count, *eof);
 
 	if (*eof)
 		return 0;
+
+	if (fmt == 2 && item_index++ >= items_to_skip) {
+		len = pp_iface_stat_line(true, outp, char_count, NULL);
+		if (len >= char_count) {
+			*outp = '\0';
+			return outp - page;
+		}
+		outp += len;
+		char_count -= len;
+		(*num_items_returned)++;
+	}
 
 	/*
 	 * This lock will prevent iface_stat_update() from changing active,
@@ -825,18 +871,29 @@ static int iface_stat_all_proc_read(char *page, char **num_items_returned,
 		} else {
 			stats = &no_dev_stats;
 		}
-		len = snprintf(outp, char_count,
-			       "%s %d "
-			       "%llu %llu %llu %llu "
-			       "%lu %lu %lu %lu\n",
-			       iface_entry->ifname,
-			       iface_entry->active,
-			       iface_entry->totals[IFS_RX].bytes,
-			       iface_entry->totals[IFS_RX].packets,
-			       iface_entry->totals[IFS_TX].bytes,
-			       iface_entry->totals[IFS_TX].packets,
-			       stats->rx_bytes, stats->rx_packets,
-			       stats->tx_bytes, stats->tx_packets);
+		/*
+		 * If the meaning of the data changes, then update the fmtX
+		 * string.
+		 */
+		if (fmt == 1) {
+			len = snprintf(
+				outp, char_count,
+				"%s %d "
+				"%llu %llu %llu %llu "
+				"%lu %lu %lu %lu\n",
+				iface_entry->ifname,
+				iface_entry->active,
+				iface_entry->totals_via_dev[IFS_RX].bytes,
+				iface_entry->totals_via_dev[IFS_RX].packets,
+				iface_entry->totals_via_dev[IFS_TX].bytes,
+				iface_entry->totals_via_dev[IFS_TX].packets,
+				stats->rx_bytes, stats->rx_packets,
+				stats->tx_bytes, stats->tx_packets
+				);
+		} else {
+			len = pp_iface_stat_line(false, outp, char_count,
+						 iface_entry);
+		}
 		if (len >= char_count) {
 			spin_unlock_bh(&iface_stat_list_lock);
 			*outp = '\0';
@@ -862,7 +919,7 @@ static void iface_create_proc_worker(struct work_struct *work)
 	/* iface_entries are not deleted, so safe to manipulate. */
 	proc_entry = proc_mkdir(new_iface->ifname, iface_stat_procdir);
 	if (IS_ERR_OR_NULL(proc_entry)) {
-		pr_err(TAG": iface_stat: create_proc(): alloc failed.\n");
+		pr_err("qtaguid: iface_stat: create_proc(): alloc failed.\n");
 		kfree(isw);
 		return;
 	}
@@ -870,17 +927,21 @@ static void iface_create_proc_worker(struct work_struct *work)
 	new_iface->proc_ptr = proc_entry;
 
 	create_proc_read_entry("tx_bytes", proc_iface_perms, proc_entry,
-			read_proc_u64, &new_iface->totals[IFS_TX].bytes);
+			       read_proc_u64,
+			       &new_iface->totals_via_dev[IFS_TX].bytes);
 	create_proc_read_entry("rx_bytes", proc_iface_perms, proc_entry,
-			read_proc_u64, &new_iface->totals[IFS_RX].bytes);
+			       read_proc_u64,
+			       &new_iface->totals_via_dev[IFS_RX].bytes);
 	create_proc_read_entry("tx_packets", proc_iface_perms, proc_entry,
-			read_proc_u64, &new_iface->totals[IFS_TX].packets);
+			       read_proc_u64,
+			       &new_iface->totals_via_dev[IFS_TX].packets);
 	create_proc_read_entry("rx_packets", proc_iface_perms, proc_entry,
-			read_proc_u64, &new_iface->totals[IFS_RX].packets);
+			       read_proc_u64,
+			       &new_iface->totals_via_dev[IFS_RX].packets);
 	create_proc_read_entry("active", proc_iface_perms, proc_entry,
 			read_proc_bool, &new_iface->active);
 
-	IF_DEBUG(TAG": iface_stat: create_proc(): done "
+	IF_DEBUG("qtaguid: iface_stat: create_proc(): done "
 		 "entry=%p dev=%s\n", new_iface, new_iface->ifname);
 	kfree(isw);
 }
@@ -896,13 +957,13 @@ static void _iface_stat_set_active(struct iface_stat *entry,
 	if (activate) {
 		entry->net_dev = net_dev;
 		entry->active = true;
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "enable tracking.\n", __func__,
 			 entry->ifname);
 	} else {
 		entry->active = false;
 		entry->net_dev = NULL;
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "disable tracking.\n", __func__,
 			 entry->ifname);
 
@@ -917,13 +978,13 @@ static struct iface_stat *iface_alloc(struct net_device *net_dev)
 
 	new_iface = kzalloc(sizeof(*new_iface), GFP_ATOMIC);
 	if (new_iface == NULL) {
-		pr_err(TAG": iface_stat: create(%s): "
+		pr_err("qtaguid: iface_stat: create(%s): "
 		       "iface_stat alloc failed\n", net_dev->name);
 		return NULL;
 	}
 	new_iface->ifname = kstrdup(net_dev->name, GFP_ATOMIC);
 	if (new_iface->ifname == NULL) {
-		pr_err(TAG": iface_stat: create(%s): "
+		pr_err("qtaguid: iface_stat: create(%s): "
 		       "ifname alloc failed\n", net_dev->name);
 		kfree(new_iface);
 		return NULL;
@@ -938,7 +999,7 @@ static struct iface_stat *iface_alloc(struct net_device *net_dev)
 	 */
 	isw = kmalloc(sizeof(*isw), GFP_ATOMIC);
 	if (!isw) {
-		pr_err(TAG": iface_stat: create(%s): "
+		pr_err("qtaguid: iface_stat: create(%s): "
 		       "work alloc failed\n", new_iface->ifname);
 		_iface_stat_set_active(new_iface, net_dev, false);
 		kfree(new_iface->ifname);
@@ -964,7 +1025,7 @@ static void iface_check_stats_reset_and_adjust(struct net_device *net_dev,
 		(stats->rx_bytes < iface->last_known[IFS_RX].bytes)
 		|| (stats->tx_bytes < iface->last_known[IFS_TX].bytes);
 
-	IF_DEBUG(TAG": %s(%s): iface=%p netdev=%p "
+	IF_DEBUG("qtaguid: %s(%s): iface=%p netdev=%p "
 		 "bytes rx/tx=%lu/%lu "
 		 "active=%d last_known=%d "
 		 "stats_rewound=%d\n", __func__,
@@ -974,18 +1035,20 @@ static void iface_check_stats_reset_and_adjust(struct net_device *net_dev,
 		 iface->active, iface->last_known_valid, stats_rewound);
 
 	if (iface->active && iface->last_known_valid && stats_rewound) {
-		pr_warn_once(TAG": iface_stat: %s(%s): "
+		pr_warn_once("qtaguid: iface_stat: %s(%s): "
 			     "iface reset its stats unexpectedly\n", __func__,
 			     net_dev->name);
 
-		iface->totals[IFS_TX].bytes += iface->last_known[IFS_TX].bytes;
-		iface->totals[IFS_TX].packets +=
+		iface->totals_via_dev[IFS_TX].bytes +=
+			iface->last_known[IFS_TX].bytes;
+		iface->totals_via_dev[IFS_TX].packets +=
 			iface->last_known[IFS_TX].packets;
-		iface->totals[IFS_RX].bytes += iface->last_known[IFS_RX].bytes;
-		iface->totals[IFS_RX].packets +=
+		iface->totals_via_dev[IFS_RX].bytes +=
+			iface->last_known[IFS_RX].bytes;
+		iface->totals_via_dev[IFS_RX].packets +=
 			iface->last_known[IFS_RX].packets;
 		iface->last_known_valid = false;
-		IF_DEBUG(TAG": %s(%s): iface=%p "
+		IF_DEBUG("qtaguid: %s(%s): iface=%p "
 			 "used last known bytes rx/tx=%llu/%llu\n", __func__,
 			 iface->ifname, iface, iface->last_known[IFS_RX].bytes,
 			 iface->last_known[IFS_TX].bytes);
@@ -1006,11 +1069,11 @@ static void iface_stat_create(struct net_device *net_dev,
 	__be32 ipaddr = 0;
 	struct iface_stat *new_iface;
 
-	IF_DEBUG(TAG": iface_stat: create(%s): ifa=%p netdev=%p\n",
+	IF_DEBUG("qtaguid: iface_stat: create(%s): ifa=%p netdev=%p\n",
 		 net_dev ? net_dev->name : "?",
 		 ifa, net_dev);
 	if (!net_dev) {
-		pr_err(TAG": iface_stat: create(): no net dev\n");
+		pr_err("qtaguid: iface_stat: create(): no net dev\n");
 		return;
 	}
 
@@ -1018,14 +1081,14 @@ static void iface_stat_create(struct net_device *net_dev,
 	if (!ifa) {
 		in_dev = in_dev_get(net_dev);
 		if (!in_dev) {
-			pr_err(TAG": iface_stat: create(%s): no inet dev\n",
+			pr_err("qtaguid: iface_stat: create(%s): no inet dev\n",
 			       ifname);
 			return;
 		}
-		IF_DEBUG(TAG": iface_stat: create(%s): in_dev=%p\n",
+		IF_DEBUG("qtaguid: iface_stat: create(%s): in_dev=%p\n",
 			 ifname, in_dev);
 		for (ifa = in_dev->ifa_list; ifa; ifa = ifa->ifa_next) {
-			IF_DEBUG(TAG": iface_stat: create(%s): "
+			IF_DEBUG("qtaguid: iface_stat: create(%s): "
 				 "ifa=%p ifa_label=%s\n",
 				 ifname, ifa,
 				 ifa->ifa_label ? ifa->ifa_label : "(null)");
@@ -1035,7 +1098,7 @@ static void iface_stat_create(struct net_device *net_dev,
 	}
 
 	if (!ifa) {
-		IF_DEBUG(TAG": iface_stat: create(%s): no matching IP\n",
+		IF_DEBUG("qtaguid: iface_stat: create(%s): no matching IP\n",
 			 ifname);
 		goto done_put;
 	}
@@ -1045,22 +1108,22 @@ static void iface_stat_create(struct net_device *net_dev,
 	entry = get_iface_entry(ifname);
 	if (entry != NULL) {
 		bool activate = !ipv4_is_loopback(ipaddr);
-		IF_DEBUG(TAG": iface_stat: create(%s): entry=%p\n",
+		IF_DEBUG("qtaguid: iface_stat: create(%s): entry=%p\n",
 			 ifname, entry);
 		iface_check_stats_reset_and_adjust(net_dev, entry);
 		_iface_stat_set_active(entry, net_dev, activate);
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "tracking now %d on ip=%pI4\n", __func__,
 			 entry->ifname, activate, &ipaddr);
 		goto done_unlock_put;
 	} else if (ipv4_is_loopback(ipaddr)) {
-		IF_DEBUG(TAG": iface_stat: create(%s): "
+		IF_DEBUG("qtaguid: iface_stat: create(%s): "
 			 "ignore loopback dev. ip=%pI4\n", ifname, &ipaddr);
 		goto done_unlock_put;
 	}
 
 	new_iface = iface_alloc(net_dev);
-	IF_DEBUG(TAG": iface_stat: create(%s): done "
+	IF_DEBUG("qtaguid: iface_stat: create(%s): done "
 		 "entry=%p ip=%pI4\n", ifname, new_iface, &ipaddr);
 done_unlock_put:
 	spin_unlock_bh(&iface_stat_list_lock);
@@ -1078,26 +1141,26 @@ static void iface_stat_create_ipv6(struct net_device *net_dev,
 	struct iface_stat *new_iface;
 	int addr_type;
 
-	IF_DEBUG(TAG": iface_stat: create6(): ifa=%p netdev=%p->name=%s\n",
+	IF_DEBUG("qtaguid: iface_stat: create6(): ifa=%p netdev=%p->name=%s\n",
 		 ifa, net_dev, net_dev ? net_dev->name : "");
 	if (!net_dev) {
-		pr_err(TAG": iface_stat: create6(): no net dev!\n");
+		pr_err("qtaguid: iface_stat: create6(): no net dev!\n");
 		return;
 	}
 	ifname = net_dev->name;
 
 	in_dev = in_dev_get(net_dev);
 	if (!in_dev) {
-		pr_err(TAG": iface_stat: create6(%s): no inet dev\n",
+		pr_err("qtaguid: iface_stat: create6(%s): no inet dev\n",
 		       ifname);
 		return;
 	}
 
-	IF_DEBUG(TAG": iface_stat: create6(%s): in_dev=%p\n",
+	IF_DEBUG("qtaguid: iface_stat: create6(%s): in_dev=%p\n",
 		 ifname, in_dev);
 
 	if (!ifa) {
-		IF_DEBUG(TAG": iface_stat: create6(%s): no matching IP\n",
+		IF_DEBUG("qtaguid: iface_stat: create6(%s): no matching IP\n",
 			 ifname);
 		goto done_put;
 	}
@@ -1107,23 +1170,23 @@ static void iface_stat_create_ipv6(struct net_device *net_dev,
 	entry = get_iface_entry(ifname);
 	if (entry != NULL) {
 		bool activate = !(addr_type & IPV6_ADDR_LOOPBACK);
-		IF_DEBUG(TAG": %s(%s): entry=%p\n", __func__,
+		IF_DEBUG("qtaguid: %s(%s): entry=%p\n", __func__,
 			 ifname, entry);
 		iface_check_stats_reset_and_adjust(net_dev, entry);
 		_iface_stat_set_active(entry, net_dev, activate);
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "tracking now %d on ip=%pI6c\n", __func__,
 			 entry->ifname, activate, &ifa->addr);
 		goto done_unlock_put;
 	} else if (addr_type & IPV6_ADDR_LOOPBACK) {
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "ignore loopback dev. ip=%pI6c\n", __func__,
 			 ifname, &ifa->addr);
 		goto done_unlock_put;
 	}
 
 	new_iface = iface_alloc(net_dev);
-	IF_DEBUG(TAG": iface_stat: create6(%s): done "
+	IF_DEBUG("qtaguid: iface_stat: create6(%s): done "
 		 "entry=%p ip=%pI6c\n", ifname, new_iface, &ifa->addr);
 
 done_unlock_put:
@@ -1134,20 +1197,43 @@ done_put:
 
 static struct sock_tag *get_sock_stat_nl(const struct sock *sk)
 {
-	MT_DEBUG(TAG": get_sock_stat_nl(sk=%p)\n", sk);
+	MT_DEBUG("qtaguid: get_sock_stat_nl(sk=%p)\n", sk);
 	return sock_tag_tree_search(&sock_tag_tree, sk);
 }
 
 static struct sock_tag *get_sock_stat(const struct sock *sk)
 {
 	struct sock_tag *sock_tag_entry;
-	MT_DEBUG(TAG": get_sock_stat(sk=%p)\n", sk);
+	MT_DEBUG("qtaguid: get_sock_stat(sk=%p)\n", sk);
 	if (!sk)
 		return NULL;
 	spin_lock_bh(&sock_tag_list_lock);
 	sock_tag_entry = get_sock_stat_nl(sk);
 	spin_unlock_bh(&sock_tag_list_lock);
 	return sock_tag_entry;
+}
+
+static int ipx_proto(const struct sk_buff *skb,
+		     const struct xt_match_param *par)
+{
+	int thoff, tproto;
+
+	switch (par->family) {
+	case NFPROTO_IPV6:
+		printk(KERN_ERR "IPV6 not supported in xt_qtaguid\n"); 
+		// FIXME
+		// tproto = ipv6_find_hdr(skb, &thoff, -1, NULL);
+		// if (tproto < 0)
+		// 	MT_DEBUG("%s(): transport header not found in ipv6"
+		// 		 " skb=%p\n", __func__, skb);
+		break;
+	case NFPROTO_IPV4:
+		tproto = ip_hdr(skb)->protocol;
+		break;
+	default:
+		tproto = IPPROTO_RAW;
+	}
+	return tproto;
 }
 
 static void
@@ -1183,16 +1269,16 @@ static void iface_stat_update(struct net_device *net_dev, bool stash_only)
 	spin_lock_bh(&iface_stat_list_lock);
 	entry = get_iface_entry(net_dev->name);
 	if (entry == NULL) {
-		IF_DEBUG(TAG": iface_stat: update(%s): not tracked\n",
+		IF_DEBUG("qtaguid: iface_stat: update(%s): not tracked\n",
 			 net_dev->name);
 		spin_unlock_bh(&iface_stat_list_lock);
 		return;
 	}
 
-	IF_DEBUG(TAG": %s(%s): entry=%p\n", __func__,
+	IF_DEBUG("qtaguid: %s(%s): entry=%p\n", __func__,
 		 net_dev->name, entry);
 	if (!entry->active) {
-		IF_DEBUG(TAG": %s(%s): already disabled\n", __func__,
+		IF_DEBUG("qtaguid: %s(%s): already disabled\n", __func__,
 			 net_dev->name);
 		spin_unlock_bh(&iface_stat_list_lock);
 		return;
@@ -1204,22 +1290,84 @@ static void iface_stat_update(struct net_device *net_dev, bool stash_only)
 		entry->last_known[IFS_RX].bytes = stats->rx_bytes;
 		entry->last_known[IFS_RX].packets = stats->rx_packets;
 		entry->last_known_valid = true;
-		IF_DEBUG(TAG": %s(%s): "
+		IF_DEBUG("qtaguid: %s(%s): "
 			 "dev stats stashed rx/tx=%lu/%lu\n", __func__,
 			 net_dev->name, stats->rx_bytes, stats->tx_bytes);
 		spin_unlock_bh(&iface_stat_list_lock);
 		return;
 	}
-	entry->totals[IFS_TX].bytes += stats->tx_bytes;
-	entry->totals[IFS_TX].packets += stats->tx_packets;
-	entry->totals[IFS_RX].bytes += stats->rx_bytes;
-	entry->totals[IFS_RX].packets += stats->rx_packets;
+	entry->totals_via_dev[IFS_TX].bytes += stats->tx_bytes;
+	entry->totals_via_dev[IFS_TX].packets += stats->tx_packets;
+	entry->totals_via_dev[IFS_RX].bytes += stats->rx_bytes;
+	entry->totals_via_dev[IFS_RX].packets += stats->rx_packets;
 	/* We don't need the last_known[] anymore */
 	entry->last_known_valid = false;
 	_iface_stat_set_active(entry, net_dev, false);
-	IF_DEBUG(TAG": %s(%s): "
+	IF_DEBUG("qtaguid: %s(%s): "
 		 "disable tracking. rx/tx=%lu/%lu\n", __func__,
 		 net_dev->name, stats->rx_bytes, stats->tx_bytes);
+	spin_unlock_bh(&iface_stat_list_lock);
+}
+
+/*
+ * Update stats for the specified interface from the skb.
+ * Do nothing if the entry
+ * does not exist (when a device was never configured with an IP address).
+ * Called on each sk.
+ */
+static void iface_stat_update_from_skb(const struct sk_buff *skb,
+				       const struct xt_match_param *par)
+{
+	struct iface_stat *entry;
+	const struct net_device *el_dev;
+	enum ifs_tx_rx direction = par->in ? IFS_RX : IFS_TX;
+	int bytes = skb->len;
+	int proto;
+
+	if (!skb->dev) {
+		MT_DEBUG("qtaguid[%d]: no skb->dev\n", par->hooknum);
+		el_dev = par->in ? : par->out;
+	} else {
+		const struct net_device *other_dev;
+		el_dev = skb->dev;
+		other_dev = par->in ? : par->out;
+		if (el_dev != other_dev) {
+			MT_DEBUG("qtaguid[%d]: skb->dev=%p %s vs "
+				 "par->(in/out)=%p %s\n",
+				 par->hooknum, el_dev, el_dev->name, other_dev,
+				 other_dev->name);
+		}
+	}
+
+	if (unlikely(!el_dev)) {
+		pr_err("qtaguid[%d]: %s(): no par->in/out?!!\n",
+				   par->hooknum, __func__);
+		BUG();
+	} else if (unlikely(!el_dev->name)) {
+		pr_err("qtaguid[%d]: %s(): no dev->name?!!\n",
+				   par->hooknum, __func__);
+		BUG();
+	} else {
+		proto = ipx_proto(skb, par);
+		MT_DEBUG("qtaguid[%d]: dev name=%s type=%d fam=%d proto=%d\n",
+			 par->hooknum, el_dev->name, el_dev->type,
+			 par->family, proto);
+	}
+
+	spin_lock_bh(&iface_stat_list_lock);
+	entry = get_iface_entry(el_dev->name);
+	if (entry == NULL) {
+		IF_DEBUG("qtaguid: iface_stat: %s(%s): not tracked\n",
+			 __func__, el_dev->name);
+		spin_unlock_bh(&iface_stat_list_lock);
+		return;
+	}
+
+	IF_DEBUG("qtaguid: %s(%s): entry=%p\n", __func__,
+		 el_dev->name, entry);
+
+	data_counters_update(&entry->totals_via_skb, 0, direction, proto,
+			     bytes);
 	spin_unlock_bh(&iface_stat_list_lock);
 }
 
@@ -1228,7 +1376,7 @@ static void tag_stat_update(struct tag_stat *tag_entry,
 {
 	int active_set;
 	active_set = get_active_counter_set(tag_entry->tn.tag);
-	MT_DEBUG(TAG": tag_stat_update(tag=0x%llx (uid=%u) set=%d "
+	MT_DEBUG("qtaguid: tag_stat_update(tag=0x%llx (uid=%u) set=%d "
 		 "dir=%d proto=%d bytes=%d)\n",
 		 tag_entry->tn.tag, get_uid_from_tag(tag_entry->tn.tag),
 		 active_set, direction, proto, bytes);
@@ -1248,12 +1396,12 @@ static struct tag_stat *create_if_tag_stat(struct iface_stat *iface_entry,
 					   tag_t tag)
 {
 	struct tag_stat *new_tag_stat_entry = NULL;
-	IF_DEBUG(TAG": iface_stat: %s(): ife=%p tag=0x%llx"
+	IF_DEBUG("qtaguid: iface_stat: %s(): ife=%p tag=0x%llx"
 		 " (uid=%u)\n", __func__,
 		 iface_entry, tag, get_uid_from_tag(tag));
 	new_tag_stat_entry = kzalloc(sizeof(*new_tag_stat_entry), GFP_ATOMIC);
 	if (!new_tag_stat_entry) {
-		pr_err(TAG": iface_stat: tag stat alloc failed\n");
+		pr_err("qtaguid: iface_stat: tag stat alloc failed\n");
 		goto done;
 	}
 	new_tag_stat_entry->tn.tag = tag;
@@ -1272,21 +1420,21 @@ static void if_tag_stat_update(const char *ifname, uid_t uid,
 	struct data_counters *uid_tag_counters;
 	struct sock_tag *sock_tag_entry;
 	struct iface_stat *iface_entry;
-	struct tag_stat *new_tag_stat;
-	MT_DEBUG(TAG": if_tag_stat_update(ifname=%s "
+	struct tag_stat *new_tag_stat = NULL;
+	MT_DEBUG("qtaguid: if_tag_stat_update(ifname=%s "
 		"uid=%u sk=%p dir=%d proto=%d bytes=%d)\n",
 		 ifname, uid, sk, direction, proto, bytes);
 
 
 	iface_entry = get_iface_entry(ifname);
 	if (!iface_entry) {
-		pr_err(TAG": iface_stat: stat_update() %s not found\n",
+		pr_err("qtaguid: iface_stat: stat_update() %s not found\n",
 		       ifname);
 		return;
 	}
 	/* It is ok to process data when an iface_entry is inactive */
 
-	MT_DEBUG(TAG": iface_stat: stat_update() dev=%s entry=%p\n",
+	MT_DEBUG("qtaguid: iface_stat: stat_update() dev=%s entry=%p\n",
 		 ifname, iface_entry);
 
 	/*
@@ -1303,7 +1451,7 @@ static void if_tag_stat_update(const char *ifname, uid_t uid,
 		tag = combine_atag_with_uid(acct_tag, uid);
 		uid_tag = make_tag_from_uid(uid);
 	}
-	MT_DEBUG(TAG": iface_stat: stat_update(): "
+	MT_DEBUG("qtaguid: iface_stat: stat_update(): "
 		 " looking for tag=0x%llx (uid=%u) in ife=%p\n",
 		 tag, get_uid_from_tag(tag), iface_entry);
 	/* Loop over tag list under this interface for {acct_tag,uid_tag} */
@@ -1337,8 +1485,19 @@ static void if_tag_stat_update(const char *ifname, uid_t uid,
 	}
 
 	if (acct_tag) {
+		/* Create the child {acct_tag, uid_tag} and hook up parent. */
 		new_tag_stat = create_if_tag_stat(iface_entry, tag);
 		new_tag_stat->parent_counters = uid_tag_counters;
+	} else {
+		/*
+		 * For new_tag_stat to be still NULL here would require:
+		 *  {0, uid_tag} exists
+		 *  and {acct_tag, uid_tag} doesn't exist
+		 *  AND acct_tag == 0.
+		 * Impossible. This reassures us that new_tag_stat
+		 * below will always be assigned.
+		 */
+		BUG_ON(!new_tag_stat);
 	}
 	tag_stat_update(new_tag_stat, direction, proto, bytes);
 	spin_unlock_bh(&iface_entry->tag_stat_list_lock);
@@ -1351,7 +1510,7 @@ static int iface_netdev_event_handler(struct notifier_block *nb,
 	if (unlikely(module_passive))
 		return NOTIFY_DONE;
 
-	IF_DEBUG(TAG": iface_stat: netdev_event(): "
+	IF_DEBUG("qtaguid: iface_stat: netdev_event(): "
 		 "ev=0x%lx/%s netdev=%p->name=%s\n",
 		 event, netdev_evt_str(event), dev, dev ? dev->name : "");
 
@@ -1378,7 +1537,7 @@ static int iface_inet6addr_event_handler(struct notifier_block *nb,
 	if (unlikely(module_passive))
 		return NOTIFY_DONE;
 
-	IF_DEBUG(TAG": iface_stat: inet6addr_event(): "
+	IF_DEBUG("qtaguid: iface_stat: inet6addr_event(): "
 		 "ev=0x%lx/%s ifa=%p\n",
 		 event, netdev_evt_str(event), ifa);
 
@@ -1409,7 +1568,7 @@ static int iface_inetaddr_event_handler(struct notifier_block *nb,
 	if (unlikely(module_passive))
 		return NOTIFY_DONE;
 
-	IF_DEBUG(TAG": iface_stat: inetaddr_event(): "
+	IF_DEBUG("qtaguid: iface_stat: inetaddr_event(): "
 		 "ev=0x%lx/%s ifa=%p\n",
 		 event, netdev_evt_str(event), ifa);
 
@@ -1449,7 +1608,7 @@ static int __init iface_stat_init(struct proc_dir_entry *parent_procdir)
 
 	iface_stat_procdir = proc_mkdir(iface_stat_procdirname, parent_procdir);
 	if (!iface_stat_procdir) {
-		pr_err(TAG": iface_stat: init failed to create proc entry\n");
+		pr_err("qtaguid: iface_stat: init failed to create proc entry\n");
 		err = -1;
 		goto err;
 	}
@@ -1458,30 +1617,43 @@ static int __init iface_stat_init(struct proc_dir_entry *parent_procdir)
 						    proc_iface_perms,
 						    parent_procdir);
 	if (!iface_stat_all_procfile) {
-		pr_err(TAG": iface_stat: init "
-		       " failed to create stat_all proc entry\n");
+		pr_err("qtaguid: iface_stat: init "
+		       " failed to create stat_old proc entry\n");
 		err = -1;
 		goto err_zap_entry;
 	}
-	iface_stat_all_procfile->read_proc = iface_stat_all_proc_read;
+	iface_stat_all_procfile->read_proc = iface_stat_fmt_proc_read;
+	iface_stat_all_procfile->data = (void *)1; /* fmt1 */
+
+	iface_stat_fmt_procfile = create_proc_entry(iface_stat_fmt_procfilename,
+						    proc_iface_perms,
+						    parent_procdir);
+	if (!iface_stat_fmt_procfile) {
+		pr_err("qtaguid: iface_stat: init "
+		       " failed to create stat_all proc entry\n");
+		err = -1;
+		goto err_zap_all_stats_entry;
+	}
+	iface_stat_fmt_procfile->read_proc = iface_stat_fmt_proc_read;
+	iface_stat_fmt_procfile->data = (void *)2; /* fmt2 */
 
 
 	err = register_netdevice_notifier(&iface_netdev_notifier_blk);
 	if (err) {
-		pr_err(TAG": iface_stat: init "
+		pr_err("qtaguid: iface_stat: init "
 		       "failed to register dev event handler\n");
-		goto err_zap_all_stats_entry;
+		goto err_zap_all_stats_entries;
 	}
 	err = register_inetaddr_notifier(&iface_inetaddr_notifier_blk);
 	if (err) {
-		pr_err(TAG": iface_stat: init "
+		pr_err("qtaguid: iface_stat: init "
 		       "failed to register ipv4 dev event handler\n");
 		goto err_unreg_nd;
 	}
 
 	err = register_inet6addr_notifier(&iface_inet6addr_notifier_blk);
 	if (err) {
-		pr_err(TAG": iface_stat: init "
+		pr_err("qtaguid: iface_stat: init "
 		       "failed to register ipv6 dev event handler\n");
 		goto err_unreg_ip4_addr;
 	}
@@ -1491,6 +1663,8 @@ err_unreg_ip4_addr:
 	unregister_inetaddr_notifier(&iface_inetaddr_notifier_blk);
 err_unreg_nd:
 	unregister_netdevice_notifier(&iface_netdev_notifier_blk);
+err_zap_all_stats_entries:
+	remove_proc_entry(iface_stat_fmt_procfilename, parent_procdir);
 err_zap_all_stats_entry:
 	remove_proc_entry(iface_stat_all_procfilename, parent_procdir);
 err_zap_entry:
@@ -1525,15 +1699,15 @@ static void account_for_uid(const struct sk_buff *skb,
 	} else if (unlikely(!el_dev->name)) {
 		pr_info("qtaguid[%d]: no dev->name?!!\n", par->hooknum);
 	} else {
-		MT_DEBUG("qtaguid[%d]: dev name=%s type=%d\n",
-			 par->hooknum,
-			 el_dev->name,
-			 el_dev->type);
+		int proto = ipx_proto(skb, par);
+		MT_DEBUG("qtaguid[%d]: dev name=%s type=%d fam=%d proto=%d\n",
+			 par->hooknum, el_dev->name, el_dev->type,
+			 par->family, proto);
 
 		if_tag_stat_update(el_dev->name, uid,
 				skb->sk ? skb->sk : alternate_sk,
 				par->in ? IFS_RX : IFS_TX,
-				ip_hdr(skb)->protocol, skb->len);
+				proto, skb->len);
 	}
 }
 
@@ -1558,8 +1732,22 @@ static bool qtaguid_mt(const struct sk_buff *skb, const struct xt_match_param *p
 		goto ret_res;
 	}
 
-	sk = skb->sk;
+	switch (par->hooknum) {
+	case NF_INET_PRE_ROUTING:
+	case NF_INET_POST_ROUTING:
+		atomic64_inc(&qtu_events.match_calls_prepost);
+		iface_stat_update_from_skb(skb, par);
+		/*
+		 * We are done in pre/post. The skb will get processed
+		 * further alter.
+		 */
+		res = (info->match ^ info->invert);
+		goto ret_res;
+		break;
+	/* default: Fall through and do UID releated work */
+	}
 
+	sk = skb->sk;
 	if (sk == NULL) {
 		/*
 		 * A missing sk->sk_socket happens when packets are in-flight
@@ -1578,8 +1766,8 @@ static bool qtaguid_mt(const struct sk_buff *skb, const struct xt_match_param *p
 	} else {
 		atomic64_inc(&qtu_events.match_found_sk);
 	}
-	MT_DEBUG("qtaguid[%d]: sk=%p got_sock=%d proto=%d\n",
-		par->hooknum, sk, got_sock, ip_hdr(skb)->protocol);
+	MT_DEBUG("qtaguid[%d]: sk=%p got_sock=%d fam=%d proto=%d\n",
+		 par->hooknum, sk, got_sock, par->family, ipx_proto(skb, par));
 	if (sk != NULL) {
 		MT_DEBUG("qtaguid[%d]: sk=%p->sk_socket=%p->file=%p\n",
 			par->hooknum, sk, sk->sk_socket,
@@ -1703,7 +1891,7 @@ static void prdebug_full_state(int indent_level, const char *fmt, ...)
 	prdebug_iface_stat_list(indent_level, &iface_stat_list);
 	spin_unlock_bh(&iface_stat_list_lock);
 
-	pr_debug(TAG": %s(): }\n", __func__);
+	pr_debug("qtaguid: %s(): }\n", __func__);
 }
 #else
 static void prdebug_full_state(int indent_level, const char *fmt, ...) {}
@@ -1734,8 +1922,10 @@ static int qtaguid_ctrl_proc_read(char *page, char **num_items_returned,
 	if (*eof)
 		return 0;
 
-	CT_DEBUG(TAG": proc ctrl page=%p off=%ld char_count=%d *eof=%d\n",
-		page, items_to_skip, char_count, *eof);
+	CT_DEBUG("qtaguid: proc ctrl pid=%u tgid=%u uid=%u "
+		 "page=%p off=%ld char_count=%d *eof=%d\n",
+		 current->pid, current->tgid, current_fsuid(),
+		 page, items_to_skip, char_count, *eof);
 
 	spin_lock_bh(&sock_tag_list_lock);
 	for (node = rb_first(&sock_tag_tree);
@@ -1745,7 +1935,7 @@ static int qtaguid_ctrl_proc_read(char *page, char **num_items_returned,
 			continue;
 		sock_tag_entry = rb_entry(node, struct sock_tag, sock_node);
 		uid = get_uid_from_tag(sock_tag_entry->tag);
-		CT_DEBUG(TAG": proc_read(): sk=%p tag=0x%llx (uid=%u) "
+		CT_DEBUG("qtaguid: proc_read(): sk=%p tag=0x%llx (uid=%u) "
 			 "pid=%u\n",
 			 sock_tag_entry->sk,
 			 sock_tag_entry->tag,
@@ -1779,6 +1969,7 @@ static int qtaguid_ctrl_proc_read(char *page, char **num_items_returned,
 			       "delete_cmds=%llu "
 			       "iface_events=%llu "
 			       "match_calls=%llu "
+			       "match_calls_prepost=%llu "
 			       "match_found_sk=%llu "
 			       "match_found_sk_in_ct=%llu "
 			       "match_found_no_sk_in_ct=%llu "
@@ -1790,6 +1981,7 @@ static int qtaguid_ctrl_proc_read(char *page, char **num_items_returned,
 			       atomic64_read(&qtu_events.delete_cmds),
 			       atomic64_read(&qtu_events.iface_events),
 			       atomic64_read(&qtu_events.match_calls),
+			       atomic64_read(&qtu_events.match_calls_prepost),
 			       atomic64_read(&qtu_events.match_found_sk),
 			       atomic64_read(&qtu_events.match_found_sk_in_ct),
 			       atomic64_read(
@@ -1836,7 +2028,7 @@ static int ctrl_cmd_delete(const char *input)
 	struct uid_tag_data *utd_entry;
 
 	argc = sscanf(input, "%c %llu %u", &cmd, &acct_tag, &uid);
-	CT_DEBUG(TAG": ctrl_delete(%s): argc=%d cmd=%c "
+	CT_DEBUG("qtaguid: ctrl_delete(%s): argc=%d cmd=%c "
 		 "user_tag=0x%llx uid=%u\n", input, argc, cmd,
 		 acct_tag, uid);
 	if (argc < 2) {
@@ -1844,14 +2036,14 @@ static int ctrl_cmd_delete(const char *input)
 		goto err;
 	}
 	if (!valid_atag(acct_tag)) {
-		pr_info(TAG": ctrl_delete(%s): invalid tag\n", input);
+		pr_info("qtaguid: ctrl_delete(%s): invalid tag\n", input);
 		res = -EINVAL;
 		goto err;
 	}
 	if (argc < 3) {
 		uid = current_fsuid();
 	} else if (!can_impersonate_uid(uid)) {
-		pr_info(TAG": ctrl_delete(%s): "
+		pr_info("qtaguid: ctrl_delete(%s): "
 			"insufficient priv from pid=%u tgid=%u uid=%u\n",
 			input, current->pid, current->tgid, current_fsuid());
 		res = -EPERM;
@@ -1859,7 +2051,7 @@ static int ctrl_cmd_delete(const char *input)
 	}
 
 	tag = combine_atag_with_uid(acct_tag, uid);
-	CT_DEBUG(TAG": ctrl_delete(%s): "
+	CT_DEBUG("qtaguid: ctrl_delete(%s): "
 		 "looking for tag=0x%llx (uid=%u)\n",
 		 input, tag, uid);
 
@@ -1873,7 +2065,7 @@ static int ctrl_cmd_delete(const char *input)
 		if (entry_uid != uid)
 			continue;
 
-		CT_DEBUG(TAG": ctrl_delete(%s): st tag=0x%llx (uid=%u)\n",
+		CT_DEBUG("qtaguid: ctrl_delete(%s): st tag=0x%llx (uid=%u)\n",
 			 input, st_entry->tag, entry_uid);
 
 		if (!acct_tag || st_entry->tag == tag) {
@@ -1903,7 +2095,7 @@ static int ctrl_cmd_delete(const char *input)
 	/* Counter sets are only on the uid tag, not full tag */
 	tcs_entry = tag_counter_set_tree_search(&tag_counter_set_tree, tag);
 	if (tcs_entry) {
-		CT_DEBUG(TAG": ctrl_delete(%s): "
+		CT_DEBUG("qtaguid: ctrl_delete(%s): "
 			 "erase tcs: tag=0x%llx (uid=%u) set=%d\n",
 			 input,
 			 tcs_entry->tn.tag,
@@ -1927,14 +2119,14 @@ static int ctrl_cmd_delete(const char *input)
 			entry_uid = get_uid_from_tag(ts_entry->tn.tag);
 			node = rb_next(node);
 
-			CT_DEBUG(TAG": ctrl_delete(%s): "
+			CT_DEBUG("qtaguid: ctrl_delete(%s): "
 				 "ts tag=0x%llx (uid=%u)\n",
 				 input, ts_entry->tn.tag, entry_uid);
 
 			if (entry_uid != uid)
 				continue;
 			if (!acct_tag || ts_entry->tn.tag == tag) {
-				CT_DEBUG(TAG": ctrl_delete(%s): "
+				CT_DEBUG("qtaguid: ctrl_delete(%s): "
 					 "erase ts: %s 0x%llx %u\n",
 					 input, iface_entry->ifname,
 					 get_atag_from_tag(ts_entry->tn.tag),
@@ -1956,7 +2148,7 @@ static int ctrl_cmd_delete(const char *input)
 		entry_uid = utd_entry->uid;
 		node = rb_next(node);
 
-		CT_DEBUG(TAG": ctrl_delete(%s): "
+		CT_DEBUG("qtaguid: ctrl_delete(%s): "
 			 "utd uid=%u\n",
 			 input, entry_uid);
 
@@ -1988,7 +2180,7 @@ static int ctrl_cmd_counter_set(const char *input)
 	int counter_set;
 
 	argc = sscanf(input, "%c %d %u", &cmd, &counter_set, &uid);
-	CT_DEBUG(TAG": ctrl_counterset(%s): argc=%d cmd=%c "
+	CT_DEBUG("qtaguid: ctrl_counterset(%s): argc=%d cmd=%c "
 		 "set=%d uid=%u\n", input, argc, cmd,
 		 counter_set, uid);
 	if (argc != 3) {
@@ -1996,13 +2188,13 @@ static int ctrl_cmd_counter_set(const char *input)
 		goto err;
 	}
 	if (counter_set < 0 || counter_set >= IFS_MAX_COUNTER_SETS) {
-		pr_info(TAG": ctrl_counterset(%s): invalid counter_set range\n",
+		pr_info("qtaguid: ctrl_counterset(%s): invalid counter_set range\n",
 			input);
 		res = -EINVAL;
 		goto err;
 	}
 	if (!can_manipulate_uids()) {
-		pr_info(TAG": ctrl_counterset(%s): "
+		pr_info("qtaguid: ctrl_counterset(%s): "
 			"insufficient priv from pid=%u tgid=%u uid=%u\n",
 			input, current->pid, current->tgid, current_fsuid());
 		res = -EPERM;
@@ -2016,7 +2208,7 @@ static int ctrl_cmd_counter_set(const char *input)
 		tcs = kzalloc(sizeof(*tcs), GFP_ATOMIC);
 		if (!tcs) {
 			spin_unlock_bh(&tag_counter_set_list_lock);
-			pr_err(TAG": ctrl_counterset(%s): "
+			pr_err("qtaguid: ctrl_counterset(%s): "
 			       "failed to alloc counter set\n",
 			       input);
 			res = -ENOMEM;
@@ -2024,7 +2216,7 @@ static int ctrl_cmd_counter_set(const char *input)
 		}
 		tcs->tn.tag = tag;
 		tag_counter_set_tree_insert(tcs, &tag_counter_set_tree);
-		CT_DEBUG(TAG": ctrl_counterset(%s): added tcs tag=0x%llx "
+		CT_DEBUG("qtaguid: ctrl_counterset(%s): added tcs tag=0x%llx "
 			 "(uid=%u) set=%d\n",
 			 input, tag, get_uid_from_tag(tag), counter_set);
 	}
@@ -2053,7 +2245,7 @@ static int ctrl_cmd_tag(const char *input)
 
 	/* Unassigned args will get defaulted later. */
 	argc = sscanf(input, "%c %d %llu %u", &cmd, &sock_fd, &acct_tag, &uid);
-	CT_DEBUG(TAG": ctrl_tag(%s): argc=%d cmd=%c sock_fd=%d "
+	CT_DEBUG("qtaguid: ctrl_tag(%s): argc=%d cmd=%c sock_fd=%d "
 		 "acct_tag=0x%llx uid=%u\n", input, argc, cmd, sock_fd,
 		 acct_tag, uid);
 	if (argc < 2) {
@@ -2062,31 +2254,34 @@ static int ctrl_cmd_tag(const char *input)
 	}
 	el_socket = sockfd_lookup(sock_fd, &res);  /* This locks the file */
 	if (!el_socket) {
-		pr_info(TAG": ctrl_tag(%s): failed to lookup"
-			" sock_fd=%d err=%d\n", input, sock_fd, res);
+		pr_info("qtaguid: ctrl_tag(%s): failed to lookup"
+			" sock_fd=%d err=%d pid=%u tgid=%u uid=%u\n",
+			input, sock_fd, res, current->pid, current->tgid,
+			current_fsuid());
 		goto err;
 	}
-	CT_DEBUG(TAG": ctrl_tag(%s): socket->...->f_count=%ld ->sk=%p\n",
+	CT_DEBUG("qtaguid: ctrl_tag(%s): socket->...->f_count=%ld ->sk=%p\n",
 		 input, atomic_long_read(&el_socket->file->f_count),
 		 el_socket->sk);
 	if (argc < 3) {
 		acct_tag = make_atag_from_value(0);
 	} else if (!valid_atag(acct_tag)) {
-		pr_info(TAG": ctrl_tag(%s): invalid tag\n", input);
+		pr_info("qtaguid: ctrl_tag(%s): invalid tag\n", input);
 		res = -EINVAL;
 		goto err_put;
 	}
-	CT_DEBUG(TAG": ctrl_tag(%s): "
+	CT_DEBUG("qtaguid: ctrl_tag(%s): "
 		 "pid=%u tgid=%u uid=%u euid=%u fsuid=%u "
-		 "in_group=%d in_egroup=%d\n",
+		 "ctrl.gid=%u in_group()=%d in_egroup()=%d\n",
 		 input, current->pid, current->tgid, current_uid(),
 		 current_euid(), current_fsuid(),
-		 in_group_p(proc_ctrl_write_gid),
-		 in_egroup_p(proc_ctrl_write_gid));
+		 xt_qtaguid_ctrl_file->gid,
+		 in_group_p(xt_qtaguid_ctrl_file->gid),
+		 in_egroup_p(xt_qtaguid_ctrl_file->gid));
 	if (argc < 4) {
 		uid = current_fsuid();
 	} else if (!can_impersonate_uid(uid)) {
-		pr_info(TAG": ctrl_tag(%s): "
+		pr_info("qtaguid: ctrl_tag(%s): "
 			"insufficient priv from pid=%u tgid=%u uid=%u\n",
 			input, current->pid, current->tgid, current_fsuid());
 		res = -EPERM;
@@ -2106,7 +2301,7 @@ static int ctrl_cmd_tag(const char *input)
 	if (sock_tag_entry) {
 		struct tag_ref *prev_tag_ref_entry;
 
-		CT_DEBUG(TAG": ctrl_tag(%s): retag for sk=%p "
+		CT_DEBUG("qtaguid: ctrl_tag(%s): retag for sk=%p "
 			 "st@%p ...->f_count=%ld\n",
 			 input, el_socket->sk, sock_tag_entry,
 			 atomic_long_read(&el_socket->file->f_count));
@@ -2124,12 +2319,12 @@ static int ctrl_cmd_tag(const char *input)
 		prev_tag_ref_entry->num_sock_tags--;
 		sock_tag_entry->tag = full_tag;
 	} else {
-		CT_DEBUG(TAG": ctrl_tag(%s): newtag for sk=%p\n",
+		CT_DEBUG("qtaguid: ctrl_tag(%s): newtag for sk=%p\n",
 			 input, el_socket->sk);
 		sock_tag_entry = kzalloc(sizeof(*sock_tag_entry),
 					 GFP_ATOMIC);
 		if (!sock_tag_entry) {
-			pr_err(TAG": ctrl_tag(%s): "
+			pr_err("qtaguid: ctrl_tag(%s): "
 			       "socket tag alloc failed\n",
 			       input);
 			spin_unlock_bh(&sock_tag_list_lock);
@@ -2151,7 +2346,7 @@ static int ctrl_cmd_tag(const char *input)
 		 */
 		if (IS_ERR_OR_NULL(pqd_entry))
 			pr_warn_once(
-				TAG": %s(): "
+				"qtaguid: %s(): "
 				"User space forgot to open /dev/xt_qtaguid? "
 				"pid=%u tgid=%u uid=%u\n", __func__,
 				current->pid, current->tgid,
@@ -2166,7 +2361,7 @@ static int ctrl_cmd_tag(const char *input)
 	}
 	spin_unlock_bh(&sock_tag_list_lock);
 	/* We keep the ref to the socket (file) until it is untagged */
-	CT_DEBUG(TAG": ctrl_tag(%s): done st@%p ...->f_count=%ld\n",
+	CT_DEBUG("qtaguid: ctrl_tag(%s): done st@%p ...->f_count=%ld\n",
 		 input, sock_tag_entry,
 		 atomic_long_read(&el_socket->file->f_count));
 	return 0;
@@ -2176,14 +2371,14 @@ err_tag_unref_put:
 	tag_ref_entry->num_sock_tags--;
 	free_tag_ref_from_utd_entry(tag_ref_entry, uid_tag_data_entry);
 err_put:
-	CT_DEBUG(TAG": ctrl_tag(%s): done. ...->f_count=%ld\n",
+	CT_DEBUG("qtaguid: ctrl_tag(%s): done. ...->f_count=%ld\n",
 		 input, atomic_long_read(&el_socket->file->f_count) - 1);
 	/* Release the sock_fd that was grabbed by sockfd_lookup(). */
 	sockfd_put(el_socket);
 	return res;
 
 err:
-	CT_DEBUG(TAG": ctrl_tag(%s): done.\n", input);
+	CT_DEBUG("qtaguid: ctrl_tag(%s): done.\n", input);
 	return res;
 }
 
@@ -2199,7 +2394,7 @@ static int ctrl_cmd_untag(const char *input)
 	struct proc_qtu_data *pqd_entry;
 
 	argc = sscanf(input, "%c %d", &cmd, &sock_fd);
-	CT_DEBUG(TAG": ctrl_untag(%s): argc=%d cmd=%c sock_fd=%d\n",
+	CT_DEBUG("qtaguid: ctrl_untag(%s): argc=%d cmd=%c sock_fd=%d\n",
 		 input, argc, cmd, sock_fd);
 	if (argc < 2) {
 		res = -EINVAL;
@@ -2207,11 +2402,13 @@ static int ctrl_cmd_untag(const char *input)
 	}
 	el_socket = sockfd_lookup(sock_fd, &res);  /* This locks the file */
 	if (!el_socket) {
-		pr_info(TAG": ctrl_untag(%s): failed to lookup"
-			" sock_fd=%d err=%d\n", input, sock_fd, res);
+		pr_info("qtaguid: ctrl_untag(%s): failed to lookup"
+			" sock_fd=%d err=%d pid=%u tgid=%u uid=%u\n",
+			input, sock_fd, res, current->pid, current->tgid,
+			current_fsuid());
 		goto err;
 	}
-	CT_DEBUG(TAG": ctrl_untag(%s): socket->...->f_count=%ld ->sk=%p\n",
+	CT_DEBUG("qtaguid: ctrl_untag(%s): socket->...->f_count=%ld ->sk=%p\n",
 		 input, atomic_long_read(&el_socket->file->f_count),
 		 el_socket->sk);
 	spin_lock_bh(&sock_tag_list_lock);
@@ -2239,7 +2436,7 @@ static int ctrl_cmd_untag(const char *input)
 	 * opening the /dev/xt_qtaguid.
 	 */
 	if (IS_ERR_OR_NULL(pqd_entry))
-		pr_warn_once(TAG": %s(): "
+		pr_warn_once("qtaguid: %s(): "
 			     "User space forgot to open /dev/xt_qtaguid? "
 			     "pid=%u tgid=%u uid=%u\n", __func__,
 			     current->pid, current->tgid, current_fsuid());
@@ -2257,7 +2454,7 @@ static int ctrl_cmd_untag(const char *input)
 	 * and once more for the sockfd_lookup() here.
 	 */
 	sockfd_put(sock_tag_entry->socket);
-	CT_DEBUG(TAG": ctrl_untag(%s): done. st@%p ...->f_count=%ld\n",
+	CT_DEBUG("qtaguid: ctrl_untag(%s): done. st@%p ...->f_count=%ld\n",
 		 input, sock_tag_entry,
 		 atomic_long_read(&el_socket->file->f_count) - 1);
 	sockfd_put(el_socket);
@@ -2268,14 +2465,14 @@ static int ctrl_cmd_untag(const char *input)
 	return 0;
 
 err_put:
-	CT_DEBUG(TAG": ctrl_untag(%s): done. socket->...->f_count=%ld\n",
+	CT_DEBUG("qtaguid: ctrl_untag(%s): done. socket->...->f_count=%ld\n",
 		 input, atomic_long_read(&el_socket->file->f_count) - 1);
 	/* Release the sock_fd that was grabbed by sockfd_lookup(). */
 	sockfd_put(el_socket);
 	return res;
 
 err:
-	CT_DEBUG(TAG": ctrl_untag(%s): done.\n", input);
+	CT_DEBUG("qtaguid: ctrl_untag(%s): done.\n", input);
 	return res;
 }
 
@@ -2283,6 +2480,9 @@ static int qtaguid_ctrl_parse(const char *input, int count)
 {
 	char cmd;
 	int res;
+
+	CT_DEBUG("qtaguid: ctrl(%s): pid=%u tgid=%u uid=%u\n",
+		 input, current->pid, current->tgid, current_fsuid());
 
 	cmd = input[0];
 	/* Collect params for commands */
@@ -2310,7 +2510,7 @@ static int qtaguid_ctrl_parse(const char *input, int count)
 	if (!res)
 		res = count;
 err:
-	CT_DEBUG(TAG": ctrl(%s): res=%d\n", input, res);
+	CT_DEBUG("qtaguid: ctrl(%s): res=%d\n", input, res);
 	return res;
 }
 
@@ -2366,12 +2566,13 @@ static int pp_stats_line(struct proc_print_info *ppi, int cnt_set)
 		uid_t stat_uid = get_uid_from_tag(tag);
 
 		if (!can_read_other_uid_stats(stat_uid)) {
-			CT_DEBUG(TAG": stats line: "
+			CT_DEBUG("qtaguid: stats line: "
 				 "%s 0x%llx %u: insufficient priv "
-				 "from pid=%u tgid=%u uid=%u\n",
+				 "from pid=%u tgid=%u uid=%u stats.gid=%u\n",
 				 ppi->iface_entry->ifname,
 				 get_atag_from_tag(tag), stat_uid,
-				 current->pid, current->tgid, current_fsuid());
+				 current->pid, current->tgid, current_fsuid(),
+				 xt_qtaguid_stats_file->gid);
 			return 0;
 		}
 		if (ppi->item_index++ < ppi->items_to_skip)
@@ -2460,9 +2661,12 @@ static int qtaguid_stats_proc_read(char *page, char **num_items_returned,
 		return len;
 	}
 
-	CT_DEBUG(TAG":proc stats page=%p *num_items_returned=%p off=%ld "
-		"char_count=%d *eof=%d\n", page, *num_items_returned,
-		items_to_skip, char_count, *eof);
+	CT_DEBUG("qtaguid:proc stats pid=%u tgid=%u uid=%u "
+		 "page=%p *num_items_returned=%p off=%ld "
+		 "char_count=%d *eof=%d\n",
+		 current->pid, current->tgid, current_fsuid(),
+		 page, *num_items_returned,
+		 items_to_skip, char_count, *eof);
 
 	if (*eof)
 		return 0;
@@ -2515,7 +2719,7 @@ static int qtudev_open(struct inode *inode, struct file *file)
 	if (unlikely(qtu_proc_handling_passive))
 		return 0;
 
-	DR_DEBUG(TAG": qtudev_open(): pid=%u tgid=%u uid=%u\n",
+	DR_DEBUG("qtaguid: qtudev_open(): pid=%u tgid=%u uid=%u\n",
 		 current->pid, current->tgid, current_fsuid());
 
 	spin_lock_bh(&uid_tag_data_tree_lock);
@@ -2531,7 +2735,7 @@ static int qtudev_open(struct inode *inode, struct file *file)
 	pqd_entry = proc_qtu_data_tree_search(&proc_qtu_data_tree,
 					      current->tgid);
 	if (pqd_entry) {
-		pr_err(TAG": qtudev_open(): %u/%u %u "
+		pr_err("qtaguid: qtudev_open(): %u/%u %u "
 		       "%s already opened\n",
 		       current->pid, current->tgid, current_fsuid(),
 		       QTU_DEV_NAME);
@@ -2541,7 +2745,7 @@ static int qtudev_open(struct inode *inode, struct file *file)
 
 	new_pqd_entry = kzalloc(sizeof(*new_pqd_entry), GFP_ATOMIC);
 	if (!new_pqd_entry) {
-		pr_err(TAG": qtudev_open(): %u/%u %u: "
+		pr_err("qtaguid: qtudev_open(): %u/%u %u: "
 		       "proc data alloc failed\n",
 		       current->pid, current->tgid, current_fsuid());
 		res = -ENOMEM;
@@ -2556,7 +2760,7 @@ static int qtudev_open(struct inode *inode, struct file *file)
 				  &proc_qtu_data_tree);
 
 	spin_unlock_bh(&uid_tag_data_tree_lock);
-	DR_DEBUG(TAG": tracking data for uid=%u in pqd=%p\n",
+	DR_DEBUG("qtaguid: tracking data for uid=%u in pqd=%p\n",
 		 current_fsuid(), new_pqd_entry);
 	file->private_data = new_pqd_entry;
 	return 0;
@@ -2587,7 +2791,7 @@ static int qtudev_release(struct inode *inode, struct file *file)
 	 * Do not trust the current->pid, it might just be a kworker cleaning
 	 * up after a dead proc.
 	 */
-	DR_DEBUG(TAG": qtudev_release(): "
+	DR_DEBUG("qtaguid: qtudev_release(): "
 		 "pid=%u tgid=%u uid=%u "
 		 "pqd_entry=%p->pid=%u utd_entry=%p->active_tags=%d\n",
 		 current->pid, current->tgid, pqd_entry->parent_tag_data->uid,
@@ -2599,7 +2803,7 @@ static int qtudev_release(struct inode *inode, struct file *file)
 
 	list_for_each_safe(entry, next, &pqd_entry->sock_tag_list) {
 		st_entry = list_entry(entry, struct sock_tag, list);
-		DR_DEBUG(TAG": %s(): "
+		DR_DEBUG("qtaguid: %s(): "
 			 "erase sock_tag=%p->sk=%p pid=%u tgid=%u uid=%u\n",
 			 __func__,
 			 st_entry, st_entry->sk,
@@ -2610,7 +2814,7 @@ static int qtudev_release(struct inode *inode, struct file *file)
 			&uid_tag_data_tree,
 			get_uid_from_tag(st_entry->tag));
 		BUG_ON(IS_ERR_OR_NULL(utd_entry));
-		DR_DEBUG(TAG": %s(): "
+		DR_DEBUG("qtaguid: %s(): "
 			 "looking for tag=0x%llx in utd_entry=%p\n", __func__,
 			 st_entry->tag, utd_entry);
 		tr = tag_ref_tree_search(&utd_entry->tag_ref_tree,
@@ -2671,7 +2875,7 @@ static int __init qtaguid_proc_register(struct proc_dir_entry **res_procdir)
 	int ret;
 	*res_procdir = proc_mkdir(module_procdirname, init_net.proc_net);
 	if (!*res_procdir) {
-		pr_err(TAG": failed to create proc/.../xt_qtaguid\n");
+		pr_err("qtaguid: failed to create proc/.../xt_qtaguid\n");
 		ret = -ENOMEM;
 		goto no_dir;
 	}
@@ -2679,7 +2883,7 @@ static int __init qtaguid_proc_register(struct proc_dir_entry **res_procdir)
 	xt_qtaguid_ctrl_file = create_proc_entry("ctrl", proc_ctrl_perms,
 						*res_procdir);
 	if (!xt_qtaguid_ctrl_file) {
-		pr_err(TAG": failed to create xt_qtaguid/ctrl "
+		pr_err("qtaguid: failed to create xt_qtaguid/ctrl "
 			" file\n");
 		ret = -ENOMEM;
 		goto no_ctrl_entry;
@@ -2690,7 +2894,7 @@ static int __init qtaguid_proc_register(struct proc_dir_entry **res_procdir)
 	xt_qtaguid_stats_file = create_proc_entry("stats", proc_stats_perms,
 						*res_procdir);
 	if (!xt_qtaguid_stats_file) {
-		pr_err(TAG": failed to create xt_qtaguid/stats "
+		pr_err("qtaguid: failed to create xt_qtaguid/stats "
 			"file\n");
 		ret = -ENOMEM;
 		goto no_stats_entry;
@@ -2744,7 +2948,6 @@ MODULE_AUTHOR("jpa <jpa@google.com>");
 MODULE_AUTHOR("Backported-by: Tanguy Pruvot <tpruvot@github>");
 MODULE_DESCRIPTION("Xtables: socket owner+tag matching and associated stats");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("1.2");
 MODULE_ALIAS("ipt_owner");
 MODULE_ALIAS("ip6t_owner");
 MODULE_ALIAS("ipt_qtaguid");

--- a/net/netfilter/xt_qtaguid_internal.h
+++ b/net/netfilter/xt_qtaguid_internal.h
@@ -91,6 +91,8 @@
 #define DR_DEBUG(...) no_printk(__VA_ARGS__)
 #endif
 
+extern uint qtaguid_debug_mask;
+
 /*---------------------------------------------------------------------------*/
 /*
  * Tags:
@@ -199,6 +201,25 @@ struct data_counters {
 	struct byte_packet_counters bpc[IFS_MAX_COUNTER_SETS][IFS_MAX_DIRECTIONS][IFS_MAX_PROTOS];
 };
 
+static inline uint64_t dc_sum_bytes(struct data_counters *counters,
+				    int set,
+				    enum ifs_tx_rx direction)
+{
+	return counters->bpc[set][direction][IFS_TCP].bytes
+		+ counters->bpc[set][direction][IFS_UDP].bytes
+		+ counters->bpc[set][direction][IFS_PROTO_OTHER].bytes;
+}
+
+static inline uint64_t dc_sum_packets(struct data_counters *counters,
+				      int set,
+				      enum ifs_tx_rx direction)
+{
+	return counters->bpc[set][direction][IFS_TCP].packets
+		+ counters->bpc[set][direction][IFS_UDP].packets
+		+ counters->bpc[set][direction][IFS_PROTO_OTHER].packets;
+}
+
+
 /* Generic X based nodes used as a base for rb_tree ops */
 struct tag_node {
 	struct rb_node node;
@@ -222,7 +243,8 @@ struct iface_stat {
 	/* net_dev is only valid for active iface_stat */
 	struct net_device *net_dev;
 
-	struct byte_packet_counters totals[IFS_MAX_DIRECTIONS];
+	struct byte_packet_counters totals_via_dev[IFS_MAX_DIRECTIONS];
+	struct data_counters totals_via_skb;
 	/*
 	 * We keep the last_known, because some devices reset their counters
 	 * just before NETDEV_UP, while some will reset just before
@@ -274,6 +296,8 @@ struct qtaguid_event_counts {
 	atomic64_t iface_events;  /* Number of NETDEV_* events handled */
 
 	atomic64_t match_calls;   /* Number of times iptables called mt */
+	/* Number of times iptables called mt from pre or post routing hooks */
+	atomic64_t match_calls_prepost;
 	/*
 	 * match_found_sk_*: numbers related to the netfilter matching
 	 * function finding a sock for the sk_buff.
@@ -345,27 +369,6 @@ struct proc_qtu_data {
 	struct list_head sock_tag_list;
 	/* No spinlock_t sock_tag_list_lock; use the global one. */
 };
-
-/* internal functions */
-struct uid_tag_data *get_uid_data(uid_t uid, bool *found_res);
-
-/*----------------------------------------------*/
-
-#ifdef TAG
-
-/* TAG is defined before the includes only in main module file */
-unsigned int qtaguid_debug_mask = DEFAULT_DEBUG_MASK;
-unsigned int qtaguid_get_debug_mask(void) {
-	return qtaguid_debug_mask;
-}
-EXPORT_SYMBOL(qtaguid_get_debug_mask);
-
-#else
-
-extern unsigned int qtaguid_get_debug_mask(void);
-#define qtaguid_debug_mask qtaguid_get_debug_mask()
-
-#endif /* TAG */
 
 /*----------------------------------------------*/
 #endif  /* ifndef __XT_QTAGUID_INTERNAL_H__ */


### PR DESCRIPTION
This is a simple upgrade of the xt_qtaguid files to the latest (I think) AOSP version, including all previous backports and some adaptations for our old kernel. 
It fixes the missing data arrows in 4.3 JB and hopefully, also some data connectivity issues. 

The main change is the new iface_stat_fmt proc file which is probably used by new Android in addition to the old iface_stat_all. I did not test the kernel on older Android versions, but since the old file is still there, I guess it should still work.
