### PR TITLE
cpcap-mapphone: Use the correct supply name for vdds_dsi.

### DIFF
--- a/drivers/mfd/cpcap-mapphone.c
+++ b/drivers/mfd/cpcap-mapphone.c
@@ -143,7 +143,7 @@ struct regulator_consumer_supply cpcap_vsdio_consumers[] = {
 };
 
 struct regulator_consumer_supply cpcap_vcsi_consumers[] = {
-	REGULATOR_SUPPLY("vcsi", NULL),
+	REGULATOR_SUPPLY("vdds_dsi", "omapdss_dsi.0"),
 };
 
 struct regulator_consumer_supply cpcap_vwlan1_consumers[] = {


### PR DESCRIPTION
cpcap-minnow indeed needs this to be named vcsi. But they're doing the
initialization different (by using m4sensorhub - which is not available
on mapphone).

Change-Id: I4a98e02b03b73d72e7dad9c6b5c8cc0d9ae050ac
