### PR TITLE
More display preparation

### DIFF
--- a/drivers/mfd/cpcap-mapphone.c
+++ b/drivers/mfd/cpcap-mapphone.c
@@ -143,6 +143,7 @@ struct regulator_consumer_supply cpcap_vsdio_consumers[] = {
 };
 
 struct regulator_consumer_supply cpcap_vcsi_consumers[] = {
+	REGULATOR_SUPPLY("vdds_dsi", "omapdss"),
 	REGULATOR_SUPPLY("vdds_dsi", "omapdss_dsi.0"),
 };
 

--- a/drivers/regulator/cpcap-regulator.c
+++ b/drivers/regulator/cpcap-regulator.c
@@ -513,7 +513,11 @@ static struct regulator_desc regulators[] = {
 	[CPCAP_SW4]      = CPCAP_REGULATOR("sw4", CPCAP_SW4),
 	[CPCAP_SW5]      = CPCAP_REGULATOR("sw5", CPCAP_SW5),
 	[CPCAP_VCAM]     = CPCAP_REGULATOR("vcam", CPCAP_VCAM),
+#ifndef CONFIG_MACH_MAPPHONE
 	[CPCAP_VCSI]     = CPCAP_REGULATOR("vcsi", CPCAP_VCSI),
+#else
+	[CPCAP_VCSI]     = CPCAP_REGULATOR("vdds_dsi", CPCAP_VCSI),
+#endif
 	[CPCAP_VDAC]     = CPCAP_REGULATOR("vdac", CPCAP_VDAC),
 	[CPCAP_VDIG]     = CPCAP_REGULATOR("vdig", CPCAP_VDIG),
 	[CPCAP_VFUSE]    = CPCAP_REGULATOR("vfuse", CPCAP_VFUSE),


### PR DESCRIPTION
This now sets vdds_dsi up like other devices do.
Still not working yet because cpcap regulators are initialized too late
